### PR TITLE
:recycle: refactor: Update Qodana workflow conditions and path

### DIFF
--- a/.github/workflows/qodana.yaml
+++ b/.github/workflows/qodana.yaml
@@ -39,8 +39,8 @@ jobs:
         env:
           QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}
       - name: Upload logs
-        if: always()
+        if: failure()
         uses: actions/upload-artifact@v2
         with:
           name: logs
-          path: ${{ runner.temp }}/qodana/results
+          path: ${{ runner.temp }}/qodana


### PR DESCRIPTION
Adjusts the conditions for log upload to occur only on failure and modifies the path of the logs.